### PR TITLE
Make sure we build wheels for the appropriate platform.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,19 @@ matrix:
   include:
   - language: generic
     os: osx
-    env: TOXENV=py27 MACOSX_DEPLOYMENT_TARGET=10.7 PLATFORM_NAME=macosx_10_7_intel
+    env: TOXENV=py27
   - language: generic
     os: osx
-    env: TOXENV=py33 MACOSX_DEPLOYMENT_TARGET=10.7 PLATFORM_NAME=macosx_10_7_intel
+    env: TOXENV=py33
   - language: generic
     os: osx
-    env: TOXENV=py34 MACOSX_DEPLOYMENT_TARGET=10.7 PLATFORM_NAME=macosx_10_7_intel
+    env: TOXENV=py34
   - language: generic
     os: osx
-    env: TOXENV=py35 MACOSX_DEPLOYMENT_TARGET=10.7 PLATFORM_NAME=macosx_10_7_intel
+    env: TOXENV=py35
   - language: generic
     os: osx
-    env: TOXENV=pypy MACOSX_DEPLOYMENT_TARGET=10.7 PLATFORM_NAME=macosx_10_7_intel
+    env: TOXENV=pypy
 
 install:
 - "./.travis/install.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,19 @@ matrix:
   include:
   - language: generic
     os: osx
-    env: TOXENV=py27
+    env: TOXENV=py27 MACOSX_DEPLOYMENT_TARGET=10.7 PLATFORM_NAME=macosx_10_7_intel
   - language: generic
     os: osx
-    env: TOXENV=py33
+    env: TOXENV=py33 MACOSX_DEPLOYMENT_TARGET=10.7 PLATFORM_NAME=macosx_10_7_intel
   - language: generic
     os: osx
-    env: TOXENV=py34
+    env: TOXENV=py34 MACOSX_DEPLOYMENT_TARGET=10.7 PLATFORM_NAME=macosx_10_7_intel
   - language: generic
     os: osx
-    env: TOXENV=py35
+    env: TOXENV=py35 MACOSX_DEPLOYMENT_TARGET=10.7 PLATFORM_NAME=macosx_10_7_intel
   - language: generic
     os: osx
-    env: TOXENV=pypy
+    env: TOXENV=pypy MACOSX_DEPLOYMENT_TARGET=10.7 PLATFORM_NAME=macosx_10_7_intel
 
 install:
 - "./.travis/install.sh"

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -9,4 +9,7 @@ eval "$(pyenv init -)"
 source ~/.venv/bin/activate
 
 tox
+
+MACOSX_DEPLOYMENT_TARGET="10.7"
+PLATFORM_NAME="macosx_10_7_intel"
 python setup.py bdist_wheel --plat-name "$PLATFORM_NAME"

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -9,4 +9,4 @@ eval "$(pyenv init -)"
 source ~/.venv/bin/activate
 
 tox
-python setup.py bdist_wheel
+python setup.py bdist_wheel --plat-name "$PLATFORM_NAME"


### PR DESCRIPTION
This ensures that we tag the OS X wheels with the appropriate architecture. It also backdates to the earliest possible SDK we can build the wheels for: 10.7.
